### PR TITLE
Add theme persistence and grid selection animation

### DIFF
--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -26,5 +26,20 @@ namespace RapiMesa.Properties
                 return defaultInstance;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool DarkMode
+        {
+            get
+            {
+                return ((bool)(this["DarkMode"]));
+            }
+            set
+            {
+                this["DarkMode"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -3,5 +3,9 @@
   <Profiles>
     <Profile Name="(Default)" />
   </Profiles>
-  <Settings />
+  <Settings>
+    <Setting Name="DarkMode" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/RapiMesa.csproj
+++ b/RapiMesa.csproj
@@ -139,6 +139,8 @@
     <Compile Include="Utility\TransactionIdGenerator.cs" />
     <Compile Include="Utility\UserSession.cs" />
     <Compile Include="Utility\ThemeManager.cs" />
+    <Compile Include="Utility\DataGridViewFader.cs" />
+    <Compile Include="Utility\PlaceholderIcons.cs" />
     <Compile Include="Views\Dashboard\Dashboard.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Utility/DataGridViewFader.cs
+++ b/Utility/DataGridViewFader.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Drawing;
+using System.Runtime.CompilerServices;
+using System.Windows.Forms;
+
+namespace RapiMesa.Utility
+{
+    public static class DataGridViewFader
+    {
+        private class FadeInfo
+        {
+            public Timer Timer { get; }
+            public Color Start { get; }
+            public Color End { get; }
+            public int Steps { get; }
+            public int Current { get; set; }
+            public DataGridViewRow Row { get; }
+            public FadeInfo(DataGridViewRow row, Color start, Color end)
+            {
+                Row = row;
+                Start = start;
+                End = end;
+                Steps = 10;
+                Timer = new Timer { Interval = 15 };
+            }
+        }
+
+        private static readonly ConditionalWeakTable<DataGridView, object> _attached =
+            new ConditionalWeakTable<DataGridView, object>();
+
+        public static void Attach(DataGridView grid)
+        {
+            if (_attached.TryGetValue(grid, out _)) return;
+            _attached.Add(grid, null);
+            grid.SelectionChanged += Grid_SelectionChanged;
+        }
+
+        private static void Grid_SelectionChanged(object sender, EventArgs e)
+        {
+            var grid = (DataGridView)sender;
+            foreach (DataGridViewRow row in grid.Rows)
+            {
+                Color baseColor = (row.Index % 2 == 1 && grid.AlternatingRowsDefaultCellStyle.BackColor != Color.Empty)
+                    ? grid.AlternatingRowsDefaultCellStyle.BackColor
+                    : grid.DefaultCellStyle.BackColor;
+                row.DefaultCellStyle.BackColor = baseColor;
+            }
+
+            foreach (DataGridViewRow row in grid.SelectedRows)
+            {
+                Color start = row.DefaultCellStyle.BackColor;
+                Color end = ThemeManager.IsDarkMode ? Color.FromArgb(63, 63, 70) : Color.LightGoldenrodYellow;
+                StartFade(new FadeInfo(row, start, end));
+            }
+        }
+
+        private static void StartFade(FadeInfo info)
+        {
+            info.Timer.Tick += (s, e) =>
+            {
+                info.Current++;
+                float t = info.Current / (float)info.Steps;
+                info.Row.DefaultCellStyle.BackColor = Lerp(info.Start, info.End, t);
+                if (info.Current >= info.Steps)
+                {
+                    info.Timer.Stop();
+                    info.Timer.Dispose();
+                }
+            };
+            info.Timer.Start();
+        }
+
+        private static Color Lerp(Color a, Color b, float t)
+        {
+            int r = (int)(a.R + (b.R - a.R) * t);
+            int g = (int)(a.G + (b.G - a.G) * t);
+            int bVal = (int)(a.B + (b.B - a.B) * t);
+            return Color.FromArgb(r, g, bVal);
+        }
+    }
+}

--- a/Utility/PlaceholderIcons.cs
+++ b/Utility/PlaceholderIcons.cs
@@ -1,0 +1,37 @@
+using System.Drawing;
+
+namespace RapiMesa.Utility
+{
+    public static class PlaceholderIcons
+    {
+        private static Bitmap Draw(System.Action<Graphics, Pen> drawAction, Color color)
+        {
+            Bitmap bmp = new Bitmap(16, 16);
+            using (Graphics g = Graphics.FromImage(bmp))
+            using (Pen pen = new Pen(color, 2))
+            {
+                g.Clear(Color.Transparent);
+                drawAction(g, pen);
+            }
+            return bmp;
+        }
+
+        public static Bitmap Add => Draw((g, p) =>
+        {
+            g.DrawLine(p, 8, 2, 8, 14);
+            g.DrawLine(p, 2, 8, 14, 8);
+        }, Color.DodgerBlue);
+
+        public static Bitmap Edit => Draw((g, p) =>
+        {
+            g.DrawRectangle(p, 3, 3, 10, 10);
+            g.DrawLine(p, 3, 3, 13, 13);
+        }, Color.SeaGreen);
+
+        public static Bitmap Delete => Draw((g, p) =>
+        {
+            g.DrawLine(p, 2, 2, 14, 14);
+            g.DrawLine(p, 14, 2, 2, 14);
+        }, Color.IndianRed);
+    }
+}

--- a/Utility/ThemeManager.cs
+++ b/Utility/ThemeManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Runtime.CompilerServices;
 using System.Windows.Forms;
+using RapiMesa.Properties;
 
 namespace RapiMesa.Utility
 {
@@ -18,6 +19,11 @@ namespace RapiMesa.Utility
 
         public static bool IsDarkMode { get; private set; }
 
+        static ThemeManager()
+        {
+            IsDarkMode = Properties.Settings.Default.DarkMode;
+        }
+
         // Guardamos colores originales sin usar Tag (evita colisiones)
         private class ControlColors
         {
@@ -32,6 +38,8 @@ namespace RapiMesa.Utility
         public static void ToggleDarkMode()
         {
             IsDarkMode = !IsDarkMode;
+            Properties.Settings.Default.DarkMode = IsDarkMode;
+            Properties.Settings.Default.Save();
             foreach (Form f in Application.OpenForms)
                 ApplyTheme(f);
         }
@@ -52,7 +60,7 @@ namespace RapiMesa.Utility
         {
             if (control == null) return;
 
-            // Opt-out f·cil
+            // Opt-out f√°cil
             if (control.Tag is string tag && tag.Equals("NoTheme", StringComparison.OrdinalIgnoreCase))
                 return;
 
@@ -136,7 +144,7 @@ namespace RapiMesa.Utility
                 else RestoreColors(control);
             }
 
-            // RecursiÛn
+            // Recursi√≥n
             foreach (Control child in control.Controls)
                 ApplyTheme(child);
         }
@@ -145,6 +153,8 @@ namespace RapiMesa.Utility
         {
             grid.ColumnHeadersDefaultCellStyle.Font = new Font("News706 BT", 12F, FontStyle.Bold);
             grid.DefaultCellStyle.Font = new Font("News706 BT", 12F, FontStyle.Bold);
+
+            DataGridViewFader.Attach(grid);
 
             if (IsDarkMode)
             {
@@ -183,7 +193,7 @@ namespace RapiMesa.Utility
             else
             {
                 grid.EnableHeadersVisualStyles = true;
-                // Restaurar lo que el diseÒador/tema del SO traiga
+                // Restaurar lo que el dise√±ador/tema del SO traiga
                 RestoreColors(grid);
                 grid.AlternatingRowsDefaultCellStyle = new DataGridViewCellStyle(); // reset
             }

--- a/Views/Category/Category.cs
+++ b/Views/Category/Category.cs
@@ -17,6 +17,13 @@ namespace RapiMesa.InventoryApp.Views
             ThemeManager.ApplyTheme(this);
             categoryManager = new CategoryManager();
 
+            button1.Image = PlaceholderIcons.Add;
+            button2.Image = PlaceholderIcons.Edit;
+            button3.Image = PlaceholderIcons.Delete;
+            button1.TextImageRelation = TextImageRelation.ImageBeforeText;
+            button2.TextImageRelation = TextImageRelation.ImageBeforeText;
+            button3.TextImageRelation = TextImageRelation.ImageBeforeText;
+
             // Cargar asíncrono cuando el form se muestra
             this.Shown -= Category_Shown;
             this.Shown += Category_Shown;

--- a/Views/MainView.cs
+++ b/Views/MainView.cs
@@ -23,6 +23,10 @@ namespace RapiMesa
             InitializeComponent();
             ThemeManager.ApplyTheme(this);
 
+            darkModeChk.CheckedChanged -= darkModeChk_CheckedChanged;
+            darkModeChk.Checked = ThemeManager.IsDarkMode;
+            darkModeChk.CheckedChanged += darkModeChk_CheckedChanged;
+
             cartManager = new CartManager();
 
             // Cargar Dashboard de entrada


### PR DESCRIPTION
## Summary
- store dark mode preference in user settings and load on startup
- animate DataGridView row selection and attach placeholder icons

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898fb256a308324a6f1d027b4caeaa8