### PR TITLE
Add validation, logging, backups and stress-test utility

### DIFF
--- a/Data/ProductManager.cs
+++ b/Data/ProductManager.cs
@@ -73,8 +73,14 @@ namespace RapiMesa.Data
         {
             name = (name ?? "").Trim();
             category = (category ?? "").Trim();
+            ValidateProductParams(name, price, stock, unit, category);
 
             var dt = await SheetsRepo.ReadTableCachedAsync("Product");
+
+            bool exists = dt.AsEnumerable()
+                            .Any(r => string.Equals(r["Name"]?.ToString()?.Trim(),
+                                                    name, StringComparison.OrdinalIgnoreCase));
+            if (exists) throw new Exception("Product already exists");
 
             // Generar Id localmente
             int newId = dt.AsEnumerable()
@@ -92,6 +98,13 @@ namespace RapiMesa.Data
             if (id <= 0) throw new ArgumentException("Invalid product id");
             name = (name ?? "").Trim();
             category = (category ?? "").Trim();
+            ValidateProductParams(name, price, stock, unit, category);
+
+            var dt = await SheetsRepo.ReadTableCachedAsync("Product");
+            bool exists = dt.AsEnumerable()
+                            .Any(r => string.Equals(r["Name"]?.ToString()?.Trim(), name, StringComparison.OrdinalIgnoreCase)
+                                       && SafeInt(r["Id"]) != id);
+            if (exists) throw new Exception("Product already exists");
 
             var (row1, _) = await SheetsRepo.FindRowByAsync("Product", "Id", id.ToString());
             if (row1 == 0) throw new Exception("Product not found");
@@ -137,7 +150,7 @@ namespace RapiMesa.Data
         public static async Task<bool> AddItemToCartAsync(string name, int price)
         {
             name = (name ?? "").Trim();
-            if (string.IsNullOrWhiteSpace(name)) return false;
+            if (string.IsNullOrWhiteSpace(name) || price <= 0) return false;
 
             int uid = UserSession.SessionUID;
 
@@ -195,5 +208,14 @@ namespace RapiMesa.Data
 
         // ---- helpers ----
         private static int SafeInt(object v) => int.TryParse(v?.ToString(), out var n) ? n : 0;
+
+        private static void ValidateProductParams(string name, int price, int stock, int unit, string category)
+        {
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name is required", nameof(name));
+            if (price <= 0) throw new ArgumentException("Price must be positive", nameof(price));
+            if (stock < 0) throw new ArgumentException("Stock cannot be negative", nameof(stock));
+            if (unit <= 0) throw new ArgumentException("Unit must be positive", nameof(unit));
+            if (string.IsNullOrWhiteSpace(category)) throw new ArgumentException("Category is required", nameof(category));
+        }
     }
 }

--- a/Data/SheetsRepo.cs
+++ b/Data/SheetsRepo.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace RapiMesa.Data
@@ -147,6 +148,39 @@ namespace RapiMesa.Data
             foreach (DataRow r in dt.Rows)
                 if (int.TryParse(r[idColumn]?.ToString(), out var v) && v > max) max = v;
             return max + 1;
+        }
+
+        public static async Task BackupAllAsync(string folder)
+        {
+            var ss = await Svc.Spreadsheets.Get(Sid).ExecuteAsync();
+            foreach (var sh in ss.Sheets)
+            {
+                var name = sh.Properties.Title;
+                var dt = await ReadTableAsync(name);
+                var path = Path.Combine(folder, $"{DateTime.Now:yyyyMMdd_HHmmss}_{name}.csv");
+                WriteCsv(dt, path);
+            }
+        }
+
+        private static void WriteCsv(DataTable dt, string path)
+        {
+            using var sw = new StreamWriter(path);
+            var headers = dt.Columns.Cast<DataColumn>().Select(c => EscapeCsv(c.ColumnName));
+            sw.WriteLine(string.Join(",", headers));
+            foreach (DataRow row in dt.Rows)
+            {
+                var fields = dt.Columns.Cast<DataColumn>()
+                    .Select(c => EscapeCsv(row[c]?.ToString() ?? string.Empty));
+                sw.WriteLine(string.Join(",", fields));
+            }
+        }
+
+        private static string EscapeCsv(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return string.Empty;
+            if (input.Contains(",") || input.Contains("\""))
+                return $"\"{input.Replace("\"", "\"\"")}\"";
+            return input;
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,9 @@ namespace RapiMesa
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
+            Application.ThreadException += (s, e) => HandleException(e.Exception);
+            AppDomain.CurrentDomain.UnhandledException += (s, e) => HandleException(e.Exception as Exception);
+
             try
             {
                 // Inicializar conexión a Google Sheets
@@ -24,17 +27,25 @@ namespace RapiMesa
             }
             catch (Exception ex)
             {
-                MessageBox.Show(
-                    $"Error al conectar con Google Sheets:\n{ex.Message}",
-                    "Error de conexión",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
+                HandleException(ex);
                 return;
             }
             SyncQueue.Start();
+            BackupService.Start();
 
             Application.Run(new UserAuth());
+        }
+
+        private static void HandleException(Exception ex)
+        {
+            if (ex == null) return;
+            ErrorLogger.Log(ex);
+            MessageBox.Show(
+                $"Ocurrió un error inesperado:\n{ex.Message}",
+                "Error",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
         }
     }
 }

--- a/RapiMesa.csproj
+++ b/RapiMesa.csproj
@@ -150,6 +150,9 @@
     <Compile Include="Utility\ThemeManager.cs" />
     <Compile Include="Utility\DataGridViewFader.cs" />
     <Compile Include="Utility\PlaceholderIcons.cs" />
+    <Compile Include="Utility\ErrorLogger.cs" />
+    <Compile Include="Utility\BackupService.cs" />
+    <Compile Include="Utility\StressTester.cs" />
     <Compile Include="Views\Dashboard\Dashboard.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Utility/BackupService.cs
+++ b/Utility/BackupService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using RapiMesa.Data;
+
+namespace RapiMesa.Utility
+{
+    public static class BackupService
+    {
+        private static Timer _timer;
+
+        public static void Start(TimeSpan? interval = null)
+        {
+            if (_timer != null) return;
+            var span = interval ?? TimeSpan.FromHours(1);
+            _timer = new Timer(async _ => await RunBackupAsync(), null, span, span);
+        }
+
+        private static async Task RunBackupAsync()
+        {
+            try
+            {
+                var folder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "db", "backups");
+                Directory.CreateDirectory(folder);
+                await SheetsRepo.BackupAllAsync(folder);
+            }
+            catch (Exception ex)
+            {
+                ErrorLogger.Log(ex);
+            }
+        }
+    }
+}

--- a/Utility/ErrorLogger.cs
+++ b/Utility/ErrorLogger.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+namespace RapiMesa.Utility
+{
+    public static class ErrorLogger
+    {
+        private static readonly string LogPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "db", "errors.log");
+
+        public static void Log(Exception ex)
+        {
+            if (ex == null) return;
+            try
+            {
+                var dir = Path.GetDirectoryName(LogPath);
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+                var line = $"{DateTime.Now:O}|{ex}";
+                File.AppendAllLines(LogPath, new[] { line });
+            }
+            catch
+            {
+                // Ignore logging errors
+            }
+        }
+    }
+}

--- a/Utility/StressTester.cs
+++ b/Utility/StressTester.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using System.Threading.Tasks;
+using RapiMesa.Data;
+
+namespace RapiMesa.Utility
+{
+    public static class StressTester
+    {
+        public static async Task RunProductInsertTestAsync(int count)
+        {
+            var pm = new ProductManager();
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < count; i++)
+            {
+                try
+                {
+                    await pm.InsertProductAsync($"Stress{i}", i + 1, i, 1, "Stress");
+                }
+                catch (System.Exception ex)
+                {
+                    ErrorLogger.Log(ex);
+                }
+            }
+            sw.Stop();
+            ErrorLogger.Log(new System.Exception($"Stress test inserted {count} products in {sw.ElapsedMilliseconds}ms"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate products and cart data to avoid empty fields, duplicates or invalid numbers
- add global exception handler with file-based logging
- implement automatic spreadsheet backups and basic stress test helper

## Testing
- `dotnet build RapiMesa.sln` *(fails: command not found)*
- `msbuild RapiMesa.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689917b14d7083249759946e63178bfe