### PR TITLE
Set default icons and add tooltiped button icons

### DIFF
--- a/Views/Category/CatDialog.Designer.cs
+++ b/Views/Category/CatDialog.Designer.cs
@@ -102,6 +102,7 @@
             this.Controls.Add(this.groupBox1);
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = System.Drawing.SystemIcons.Application;
             this.Name = "CatDialog";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/Views/Category/Category.Designer.cs
+++ b/Views/Category/Category.Designer.cs
@@ -28,6 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
             this.DeleteBtn = new System.Windows.Forms.Button();
@@ -76,7 +78,9 @@
             this.DeleteBtn.Name = "DeleteBtn";
             this.DeleteBtn.Size = new System.Drawing.Size(113, 30);
             this.DeleteBtn.TabIndex = 7;
-            this.DeleteBtn.Text = "ELIMINAR";
+            this.DeleteBtn.Text = "";
+            this.DeleteBtn.Image = System.Drawing.SystemIcons.Error.ToBitmap();
+            this.toolTip1.SetToolTip(this.DeleteBtn, "Eliminar");
             this.DeleteBtn.UseVisualStyleBackColor = true;
             this.DeleteBtn.Click += new System.EventHandler(this.button3_Click);
             // 
@@ -87,7 +91,9 @@
             this.EditBtn.Name = "EditBtn";
             this.EditBtn.Size = new System.Drawing.Size(113, 30);
             this.EditBtn.TabIndex = 6;
-            this.EditBtn.Text = "EDITAR";
+            this.EditBtn.Text = "";
+            this.EditBtn.Image = System.Drawing.SystemIcons.Warning.ToBitmap();
+            this.toolTip1.SetToolTip(this.EditBtn, "Editar");
             this.EditBtn.UseVisualStyleBackColor = true;
             this.EditBtn.Click += new System.EventHandler(this.button2_Click);
             // 
@@ -98,7 +104,9 @@
             this.AddBtn.Name = "AddBtn";
             this.AddBtn.Size = new System.Drawing.Size(113, 30);
             this.AddBtn.TabIndex = 5;
-            this.AddBtn.Text = "AGREGAR";
+            this.AddBtn.Text = "";
+            this.AddBtn.Image = System.Drawing.SystemIcons.Application.ToBitmap();
+            this.toolTip1.SetToolTip(this.AddBtn, "Agregar");
             this.AddBtn.UseVisualStyleBackColor = true;
             this.AddBtn.Click += new System.EventHandler(this.button1_Click);
             // 
@@ -112,6 +120,7 @@
             this.Controls.Add(this.EditBtn);
             this.Controls.Add(this.AddBtn);
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
+            this.Icon = System.Drawing.SystemIcons.Application;
             this.Name = "Category";
             this.Text = "Category";
             this.groupBox1.ResumeLayout(false);
@@ -127,5 +136,6 @@
         private System.Windows.Forms.Button DeleteBtn;
         private System.Windows.Forms.Button EditBtn;
         private System.Windows.Forms.Button AddBtn;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Views/Dashboard/Dashboard.Designer.cs
+++ b/Views/Dashboard/Dashboard.Designer.cs
@@ -349,6 +349,8 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
 
+            this.Icon = System.Drawing.SystemIcons.Application;
+
             this.Name = "Dashboard";
             this.Text = "Dashboard";
             this.tableKpis.ResumeLayout(false);

--- a/Views/MainView.Designer.cs
+++ b/Views/MainView.Designer.cs
@@ -191,6 +191,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.MinimumSize = new System.Drawing.Size(1406, 771);
+            this.Icon = System.Drawing.SystemIcons.Application;
             this.Name = "MainView";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "RapiMesa";

--- a/Views/Product/AddStock.Designer.cs
+++ b/Views/Product/AddStock.Designer.cs
@@ -28,6 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.label1 = new System.Windows.Forms.Label();
             this.textBox2 = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
@@ -71,7 +73,9 @@
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(111, 41);
             this.button1.TabIndex = 10;
-            this.button1.Text = "AGREGAR";
+            this.button1.Text = "";
+            this.button1.Image = System.Drawing.SystemIcons.Application.ToBitmap();
+            this.toolTip1.SetToolTip(this.button1, "Agregar");
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
@@ -81,7 +85,9 @@
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(116, 41);
             this.button2.TabIndex = 11;
-            this.button2.Text = "CANCELAR";
+            this.button2.Text = "";
+            this.button2.Image = System.Drawing.SystemIcons.Hand.ToBitmap();
+            this.toolTip1.SetToolTip(this.button2, "Cancelar");
             this.button2.UseVisualStyleBackColor = true;
             this.button2.Click += new System.EventHandler(this.button2_Click);
             // 
@@ -127,6 +133,7 @@
             this.Controls.Add(this.groupBox1);
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = System.Drawing.SystemIcons.Application;
             this.Name = "AddStock";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
@@ -148,5 +155,6 @@
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Views/Product/History.Designer.cs
+++ b/Views/Product/History.Designer.cs
@@ -70,6 +70,8 @@
             this.MinimizeBox = false;
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
 
+            this.Icon = System.Drawing.SystemIcons.Application;
+
             this.Name = "History";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;

--- a/Views/Product/Product.Designer.cs
+++ b/Views/Product/Product.Designer.cs
@@ -28,6 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.AddBtn = new System.Windows.Forms.Button();
             this.EditBtn = new System.Windows.Forms.Button();
             this.DeleteBtn = new System.Windows.Forms.Button();
@@ -58,7 +60,9 @@
             this.AddBtn.Name = "AddBtn";
             this.AddBtn.Size = new System.Drawing.Size(150, 44);
             this.AddBtn.TabIndex = 0;
-            this.AddBtn.Text = "AGREGAR";
+            this.AddBtn.Text = "";
+            this.AddBtn.Image = System.Drawing.SystemIcons.Application.ToBitmap();
+            this.toolTip1.SetToolTip(this.AddBtn, "Agregar");
             this.AddBtn.UseVisualStyleBackColor = true;
             this.AddBtn.Click += new System.EventHandler(this.Add_Click);
             // 
@@ -70,7 +74,9 @@
             this.EditBtn.Name = "EditBtn";
             this.EditBtn.Size = new System.Drawing.Size(150, 44);
             this.EditBtn.TabIndex = 1;
-            this.EditBtn.Text = "EDITAR";
+            this.EditBtn.Text = "";
+            this.EditBtn.Image = System.Drawing.SystemIcons.Warning.ToBitmap();
+            this.toolTip1.SetToolTip(this.EditBtn, "Editar");
             this.EditBtn.UseVisualStyleBackColor = true;
             this.EditBtn.Click += new System.EventHandler(this.button2_Click);
             // 
@@ -82,7 +88,9 @@
             this.DeleteBtn.Name = "DeleteBtn";
             this.DeleteBtn.Size = new System.Drawing.Size(150, 44);
             this.DeleteBtn.TabIndex = 2;
-            this.DeleteBtn.Text = "ELIMINAR";
+            this.DeleteBtn.Text = "";
+            this.DeleteBtn.Image = System.Drawing.SystemIcons.Error.ToBitmap();
+            this.toolTip1.SetToolTip(this.DeleteBtn, "Eliminar");
             this.DeleteBtn.UseVisualStyleBackColor = true;
             this.DeleteBtn.Click += new System.EventHandler(this.DeleteBtn_Click);
 
@@ -94,7 +102,9 @@
             this.ExportBtn.Name = "ExportBtn";
             this.ExportBtn.Size = new System.Drawing.Size(169, 44);
             this.ExportBtn.TabIndex = 13;
-            this.ExportBtn.Text = "EXPORTAR";
+            this.ExportBtn.Text = "";
+            this.ExportBtn.Image = System.Drawing.SystemIcons.WinLogo.ToBitmap();
+            this.toolTip1.SetToolTip(this.ExportBtn, "Exportar");
             this.ExportBtn.UseVisualStyleBackColor = true;
             this.ExportBtn.Click += new System.EventHandler(this.ExportBtn_Click);
 
@@ -143,7 +153,9 @@
             this.AddStockBtn.Name = "AddStockBtn";
             this.AddStockBtn.Size = new System.Drawing.Size(169, 44);
             this.AddStockBtn.TabIndex = 4;
-            this.AddStockBtn.Text = "AGREGAR STOCK";
+            this.AddStockBtn.Text = "";
+            this.AddStockBtn.Image = System.Drawing.SystemIcons.Asterisk.ToBitmap();
+            this.toolTip1.SetToolTip(this.AddStockBtn, "Agregar stock");
             this.AddStockBtn.UseVisualStyleBackColor = true;
             this.AddStockBtn.Click += new System.EventHandler(this.AddStockBtn_Click);
             // 
@@ -155,7 +167,9 @@
             this.HistoryBtn.Name = "HistoryBtn";
             this.HistoryBtn.Size = new System.Drawing.Size(169, 44);
             this.HistoryBtn.TabIndex = 5;
-            this.HistoryBtn.Text = "HISTORIAL";
+            this.HistoryBtn.Text = "";
+            this.HistoryBtn.Image = System.Drawing.SystemIcons.Information.ToBitmap();
+            this.toolTip1.SetToolTip(this.HistoryBtn, "Historial");
             this.HistoryBtn.UseVisualStyleBackColor = true;
             this.HistoryBtn.Click += new System.EventHandler(this.button5_Click);
             // 
@@ -179,7 +193,9 @@
             this.SearchBtn.Name = "SearchBtn";
             this.SearchBtn.Size = new System.Drawing.Size(125, 34);
             this.SearchBtn.TabIndex = 0;
-            this.SearchBtn.Text = "BUSCAR";
+            this.SearchBtn.Text = "";
+            this.SearchBtn.Image = System.Drawing.SystemIcons.Question.ToBitmap();
+            this.toolTip1.SetToolTip(this.SearchBtn, "Buscar");
             this.SearchBtn.UseVisualStyleBackColor = true;
             this.SearchBtn.Click += new System.EventHandler(this.button6_Click);
             //
@@ -267,6 +283,7 @@
             this.Controls.Add(this.AddBtn);
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
             this.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            this.Icon = System.Drawing.SystemIcons.Application;
             this.Name = "Product";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Producto";
@@ -297,6 +314,7 @@
         private System.Windows.Forms.Label labelMaxPrice;
         private System.Windows.Forms.NumericUpDown numericMaxPrice;
         private System.Windows.Forms.Button ExportBtn;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }
 

--- a/Views/Product/ProductDialog.Designer.cs
+++ b/Views/Product/ProductDialog.Designer.cs
@@ -189,6 +189,7 @@
             this.Controls.Add(this.groupBox1);
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = System.Drawing.SystemIcons.Application;
             this.Name = "ProductDialog";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/Views/Sale/Checkout.Designer.cs
+++ b/Views/Sale/Checkout.Designer.cs
@@ -28,8 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
-            
-
+            this.components = new System.ComponentModel.Container();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.label1 = new System.Windows.Forms.Label();
             this.CashTxt = new System.Windows.Forms.TextBox();
             this.CashLbl = new System.Windows.Forms.Label();
@@ -87,7 +87,9 @@
             this.CancelBtn.Name = "CancelBtn";
             this.CancelBtn.Size = new System.Drawing.Size(115, 41);
             this.CancelBtn.TabIndex = 10;
-            this.CancelBtn.Text = "CANCELAR";
+            this.CancelBtn.Text = "";
+            this.CancelBtn.Image = System.Drawing.SystemIcons.Hand.ToBitmap();
+            this.toolTip1.SetToolTip(this.CancelBtn, "Cancelar");
             this.CancelBtn.UseVisualStyleBackColor = false;
             this.CancelBtn.Click += new System.EventHandler(this.button2_Click);
             // 
@@ -99,7 +101,9 @@
             this.PayBtn.Name = "PayBtn";
             this.PayBtn.Size = new System.Drawing.Size(111, 41);
             this.PayBtn.TabIndex = 11;
-            this.PayBtn.Text = "PAGAR";
+            this.PayBtn.Text = "";
+            this.PayBtn.Image = System.Drawing.SystemIcons.Shield.ToBitmap();
+            this.toolTip1.SetToolTip(this.PayBtn, "Pagar");
             this.PayBtn.UseVisualStyleBackColor = false;
             this.PayBtn.Click += new System.EventHandler(this.button1_Click);
             // 
@@ -238,6 +242,8 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
 
+            this.Icon = System.Drawing.SystemIcons.Application;
+
             this.Name = "Checkout";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
@@ -265,5 +271,6 @@
         private System.Windows.Forms.ComboBox DiscountCmb;
         private System.Windows.Forms.Label ChangeLbl;
         private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Views/Sale/Quantity.Designer.cs
+++ b/Views/Sale/Quantity.Designer.cs
@@ -109,6 +109,8 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
 
+            this.Icon = System.Drawing.SystemIcons.Application;
+
             this.Name = "Quantity";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/Views/Sale/Sale.Designer.cs
+++ b/Views/Sale/Sale.Designer.cs
@@ -28,6 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
             this.button2 = new System.Windows.Forms.Button();
@@ -76,7 +78,9 @@
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(115, 30);
             this.button2.TabIndex = 6;
-            this.button2.Text = "ELIMINAR";
+            this.button2.Text = "";
+            this.button2.Image = System.Drawing.SystemIcons.Error.ToBitmap();
+            this.toolTip1.SetToolTip(this.button2, "Eliminar");
             this.button2.UseVisualStyleBackColor = true;
             this.button2.Click += new System.EventHandler(this.button2_Click);
             // 
@@ -87,7 +91,9 @@
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(115, 30);
             this.button1.TabIndex = 5;
-            this.button1.Text = "COBRAR";
+            this.button1.Text = "";
+            this.button1.Image = System.Drawing.SystemIcons.Shield.ToBitmap();
+            this.toolTip1.SetToolTip(this.button1, "Cobrar");
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
@@ -98,7 +104,9 @@
             this.button4.Name = "button4";
             this.button4.Size = new System.Drawing.Size(115, 30);
             this.button4.TabIndex = 8;
-            this.button4.Text = "CANTIDAD";
+            this.button4.Text = "";
+            this.button4.Image = System.Drawing.SystemIcons.Question.ToBitmap();
+            this.toolTip1.SetToolTip(this.button4, "Cantidad");
             this.button4.UseVisualStyleBackColor = true;
             this.button4.Click += new System.EventHandler(this.button4_Click);
             // 
@@ -112,6 +120,7 @@
             this.Controls.Add(this.button2);
             this.Controls.Add(this.button1);
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
+            this.Icon = System.Drawing.SystemIcons.Application;
             this.Name = "Sale";
             this.Text = "Carrito";
             this.groupBox1.ResumeLayout(false);
@@ -127,5 +136,6 @@
         private System.Windows.Forms.Button button2;
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.Button button4;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Views/Transaction/Details.Designer.cs
+++ b/Views/Transaction/Details.Designer.cs
@@ -70,6 +70,8 @@
             this.MinimizeBox = false;
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
 
+            this.Icon = System.Drawing.SystemIcons.Application;
+
             this.Name = "Details";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;

--- a/Views/Transaction/Transaction.Designer.cs
+++ b/Views/Transaction/Transaction.Designer.cs
@@ -77,6 +77,8 @@
             this.MinimizeBox = false;
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
 
+            this.Icon = System.Drawing.SystemIcons.Application;
+
             this.Name = "Transaction";
             this.ShowIcon = false;
             this.Text = "Transaction";

--- a/Views/UserAuth.Designer.cs
+++ b/Views/UserAuth.Designer.cs
@@ -150,6 +150,8 @@
             this.MinimizeBox = false;
             this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
 
+            this.Icon = System.Drawing.SystemIcons.Application;
+
             this.Name = "UserAuth";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "UserAuth";


### PR DESCRIPTION
## Summary
- add a default `SystemIcons.Application` icon to every WinForms designer
- replace button text for add/delete/cobrar actions with `SystemIcons` images and show their descriptions via tooltips

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68991cd8eebc8324b288af1ec23b65d5