### PR TITLE
Add security roles, audit logging, inactivity lock, and account management

### DIFF
--- a/Data/AccountManager.cs
+++ b/Data/AccountManager.cs
@@ -35,8 +35,9 @@ namespace RapiMesa.Data
                 {
                     int uid = ToInt(r["Uid"]);
                     int row1 = FindRow1(dt, r); // fila 1-based (incluye header)
+                    var roleVal = dt.Columns.Contains("Role") ? r["Role"]?.ToString() : "";
                     await SheetsRepo.UpdateRowAsync("Account", row1,
-                        new object[] { uid, user, HashPassword(password) });
+                        new object[] { uid, user, HashPassword(password), roleVal });
                     return uid;
                 }
 
@@ -45,8 +46,14 @@ namespace RapiMesa.Data
             return 0; // no existe
         }
 
-        // Registra usuario (con hash); muestra mensajes como antes
-        public async Task RegisterUserAsync(string username, string password)
+        // Obtiene todas las cuentas
+        public async Task<DataTable> GetAccountsAsync()
+        {
+            return await SheetsRepo.ReadTableCachedAsync("Account");
+        }
+
+        // Registra usuario (con hash) y rol
+        public async Task RegisterUserAsync(string username, string password, UserRole role = UserRole.Cashier)
         {
             if (await IsUsernameExistsAsync(username))
             {
@@ -59,7 +66,8 @@ namespace RapiMesa.Data
 
             int uid = await SheetsRepo.NextIdAsync("Account", "Uid");
             await SheetsRepo.AppendRowAsync("Account",
-                new object[] { uid, username, HashPassword(password) });
+                new object[] { uid, username, HashPassword(password), role.ToString() });
+            SheetsRepo.Invalidate("Account");
 
             MessageBox.Show(
                 "Registro exitoso",
@@ -68,15 +76,50 @@ namespace RapiMesa.Data
         }
 
         // Comprueba si ya existe el username
-        public async Task<bool> IsUsernameExistsAsync(string username)
+        public async Task<bool> IsUsernameExistsAsync(string username, int excludeUid = 0)
         {
             var dt = await SheetsRepo.ReadTableCachedAsync("Account");
             foreach (DataRow r in dt.Rows)
             {
-                if (string.Equals(r["Username"]?.ToString(), username, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(r["Username"]?.ToString(), username, StringComparison.OrdinalIgnoreCase)
+                    && ToInt(r["Uid"]) != excludeUid)
                     return true;
             }
             return false;
+        }
+
+        // Actualiza usuario existente
+        public async Task UpdateUserAsync(int uid, string username, string password, UserRole role)
+        {
+            if (await IsUsernameExistsAsync(username, uid))
+            {
+                MessageBox.Show(
+                    "El nombre de usuario ya existe.",
+                    "Error",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var (row1, row) = await SheetsRepo.FindRowByAsync("Account", "Uid", uid.ToString());
+            if (row1 <= 0) return;
+
+            string passHash = string.IsNullOrWhiteSpace(password)
+                ? row["Password"]?.ToString() ?? ""
+                : HashPassword(password);
+
+            await SheetsRepo.UpdateRowAsync("Account", row1,
+                new object[] { uid, username, passHash, role.ToString() });
+            SheetsRepo.Invalidate("Account");
+        }
+
+        // Elimina usuario
+        public async Task DeleteUserAsync(int uid)
+        {
+            var (row1, _) = await SheetsRepo.FindRowByAsync("Account", "Uid", uid.ToString());
+            if (row1 <= 0) return;
+
+            await SheetsRepo.DeleteRowAsync("Account", row1 - 1);
+            SheetsRepo.Invalidate("Account");
         }
 
         public async Task<UserRole> GetUserRoleAsync(int uid)

--- a/Data/ProductManager.cs
+++ b/Data/ProductManager.cs
@@ -106,12 +106,29 @@ namespace RapiMesa.Data
                                        && SafeInt(r["Id"]) != id);
             if (exists) throw new Exception("Product already exists");
 
-            var (row1, _) = await SheetsRepo.FindRowByAsync("Product", "Id", id.ToString());
-            if (row1 == 0) throw new Exception("Product not found");
+            var (row1, row) = await SheetsRepo.FindRowByAsync("Product", "Id", id.ToString());
+            if (row1 == 0 || row == null) throw new Exception("Product not found");
+
+            int oldPrice = SafeInt(row["Price"]);
+            int oldStock = SafeInt(row["Stock"]);
 
             SyncQueue.Enqueue(new UpdateRowOp("Product", row1, new object[] { id, name, price, stock, unit, category }));
             SheetsRepo.Invalidate("Product");
-            ChangeLogger.Log(UserSession.SessionUID.ToString(), "Update", "Product", $"{id}:{name}");
+
+            string details = $"{id}:{name}";
+            bool changed = false;
+            if (oldPrice != price)
+            {
+                details += $"|Price {oldPrice}->{price}";
+                changed = true;
+            }
+            if (oldStock != stock)
+            {
+                details += $"|Stock {oldStock}->{stock}";
+                changed = true;
+            }
+            if (changed)
+                ChangeLogger.Log(UserSession.SessionUID.ToString(), "Update", "Product", details);
         }
 
         public async Task DeleteProductAsync(int id)

--- a/Data/StockManager.cs
+++ b/Data/StockManager.cs
@@ -45,6 +45,8 @@ namespace RapiMesa.Data
             var (row1, row) = await SheetsRepo.FindRowByAsync("Product", "Id", productId.ToString());
             if (row1 == 0 || row == null) throw new Exception("Product not found");
 
+            int oldStock = ToInt(row["Stock"]);
+
             // Reescribimos fila completa por consistencia
             var values = new object[]
             {
@@ -58,6 +60,8 @@ namespace RapiMesa.Data
 
             SyncQueue.Enqueue(new UpdateRowOp("Product", row1, values));
             SheetsRepo.Invalidate("Product");
+            if (oldStock != newStock)
+                ChangeLogger.Log(UserSession.SessionUID.ToString(), "StockUpdate", "Product", $"{productId}:{oldStock}->{newStock}");
         }
 
         // 4) Insertar historial de stocks (Append en background, Id local)

--- a/RapiMesa.csproj
+++ b/RapiMesa.csproj
@@ -200,6 +200,12 @@
     <Compile Include="Views\Category\CatDialog.Designer.cs">
       <DependentUpon>CatDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Views\Account\UserDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Views\Account\UserDialog.Designer.cs">
+      <DependentUpon>UserDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Data\ConnectionManager.cs" />
     <Compile Include="Views\MainView.cs">
       <SubType>Form</SubType>
@@ -212,6 +218,12 @@
     </Compile>
     <Compile Include="Views\Category\Category.Designer.cs">
       <DependentUpon>Category.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Account\Accounts.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Views\Account\Accounts.Designer.cs">
+      <DependentUpon>Accounts.cs</DependentUpon>
     </Compile>
     <Compile Include="Views\Product\AddStock.cs">
       <SubType>Form</SubType>
@@ -266,11 +278,17 @@
     <EmbeddedResource Include="Views\Category\CatDialog.resx">
       <DependentUpon>CatDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Views\Account\UserDialog.resx">
+      <DependentUpon>UserDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Views\MainView.resx">
       <DependentUpon>MainView.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Views\Category\Category.resx">
       <DependentUpon>Category.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Views\Account\Accounts.resx">
+      <DependentUpon>Accounts.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Views\Product\AddStock.resx">
       <DependentUpon>AddStock.cs</DependentUpon>

--- a/Utility/InactivityMonitor.cs
+++ b/Utility/InactivityMonitor.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Windows.Forms;
+
+namespace RapiMesa.Utility
+{
+    public static class InactivityMonitor
+    {
+        private static Timer _timer;
+        private static ActivityFilter _filter;
+        private static Action _onTimeout;
+
+        private class ActivityFilter : IMessageFilter
+        {
+            public event EventHandler Activity;
+            public bool PreFilterMessage(ref Message m)
+            {
+                const int WM_MOUSEMOVE = 0x0200;
+                const int WM_KEYDOWN = 0x0100;
+                const int WM_LBUTTONDOWN = 0x0201;
+                const int WM_RBUTTONDOWN = 0x0204;
+                const int WM_MBUTTONDOWN = 0x0207;
+
+                switch (m.Msg)
+                {
+                    case WM_MOUSEMOVE:
+                    case WM_KEYDOWN:
+                    case WM_LBUTTONDOWN:
+                    case WM_RBUTTONDOWN:
+                    case WM_MBUTTONDOWN:
+                        Activity?.Invoke(this, EventArgs.Empty);
+                        break;
+                }
+                return false;
+            }
+        }
+
+        public static void Start(int timeoutSeconds, Action onTimeout)
+        {
+            _onTimeout = onTimeout;
+            _timer = new Timer { Interval = timeoutSeconds * 1000 };
+            _timer.Tick += (s, e) =>
+            {
+                _timer.Stop();
+                _onTimeout?.Invoke();
+            };
+            _timer.Start();
+
+            _filter = new ActivityFilter();
+            _filter.Activity += (s, e) => Reset();
+            Application.AddMessageFilter(_filter);
+        }
+
+        public static void Reset()
+        {
+            if (_timer == null) return;
+            _timer.Stop();
+            _timer.Start();
+        }
+
+        public static void Stop()
+        {
+            if (_filter != null)
+            {
+                Application.RemoveMessageFilter(_filter);
+                _filter = null;
+            }
+            _timer?.Stop();
+            _timer = null;
+        }
+    }
+}

--- a/Utility/UserRole.cs
+++ b/Utility/UserRole.cs
@@ -3,7 +3,7 @@ namespace RapiMesa.Utility
     public enum UserRole
     {
         Administrator,
-        Waiter,
+        Supervisor,
         Cashier
     }
 }

--- a/Views/Account/Accounts.Designer.cs
+++ b/Views/Account/Accounts.Designer.cs
@@ -1,0 +1,119 @@
+namespace RapiMesa.InventoryApp.Views
+{
+    partial class Accounts
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.AddBtn = new System.Windows.Forms.Button();
+            this.EditBtn = new System.Windows.Forms.Button();
+            this.DeleteBtn = new System.Windows.Forms.Button();
+            this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.dataGridView1);
+            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(631, 477);
+            this.groupBox1.TabIndex = 0;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Cuentas";
+            // 
+            // dataGridView1
+            // 
+            this.dataGridView1.AllowUserToAddRows = false;
+            this.dataGridView1.AllowUserToDeleteRows = false;
+            this.dataGridView1.AllowUserToResizeColumns = false;
+            this.dataGridView1.AllowUserToResizeRows = false;
+            this.dataGridView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dataGridView1.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridView1.Location = new System.Drawing.Point(13, 20);
+            this.dataGridView1.Name = "dataGridView1";
+            this.dataGridView1.ReadOnly = true;
+            this.dataGridView1.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dataGridView1.Size = new System.Drawing.Size(605, 442);
+            this.dataGridView1.TabIndex = 0;
+            // 
+            // AddBtn
+            // 
+            this.AddBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.AddBtn.Location = new System.Drawing.Point(649, 32);
+            this.AddBtn.Name = "AddBtn";
+            this.AddBtn.Size = new System.Drawing.Size(113, 60);
+            this.AddBtn.TabIndex = 1;
+            this.AddBtn.Text = "Agregar";
+            this.AddBtn.UseVisualStyleBackColor = true;
+            this.AddBtn.Click += new System.EventHandler(this.AddBtn_Click);
+            // 
+            // EditBtn
+            // 
+            this.EditBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.EditBtn.Location = new System.Drawing.Point(649, 98);
+            this.EditBtn.Name = "EditBtn";
+            this.EditBtn.Size = new System.Drawing.Size(113, 60);
+            this.EditBtn.TabIndex = 2;
+            this.EditBtn.Text = "Editar";
+            this.EditBtn.UseVisualStyleBackColor = true;
+            this.EditBtn.Click += new System.EventHandler(this.EditBtn_Click);
+            // 
+            // DeleteBtn
+            // 
+            this.DeleteBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.DeleteBtn.Location = new System.Drawing.Point(649, 164);
+            this.DeleteBtn.Name = "DeleteBtn";
+            this.DeleteBtn.Size = new System.Drawing.Size(113, 60);
+            this.DeleteBtn.TabIndex = 3;
+            this.DeleteBtn.Text = "Eliminar";
+            this.DeleteBtn.UseVisualStyleBackColor = true;
+            this.DeleteBtn.Click += new System.EventHandler(this.DeleteBtn_Click);
+            // 
+            // Accounts
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 19F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(774, 501);
+            this.Controls.Add(this.DeleteBtn);
+            this.Controls.Add(this.EditBtn);
+            this.Controls.Add(this.AddBtn);
+            this.Controls.Add(this.groupBox1);
+            this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
+            this.Name = "Accounts";
+            this.Text = "Cuentas";
+            this.groupBox1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.DataGridView dataGridView1;
+        private System.Windows.Forms.Button AddBtn;
+        private System.Windows.Forms.Button EditBtn;
+        private System.Windows.Forms.Button DeleteBtn;
+    }
+}

--- a/Views/Account/Accounts.cs
+++ b/Views/Account/Accounts.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using RapiMesa.Utility;
+using RapiMesa.Data;
+using RapiMesa;
+
+namespace RapiMesa.InventoryApp.Views
+{
+    public partial class Accounts : Form
+    {
+        private readonly AccountManager accountManager;
+
+        public Accounts()
+        {
+            InitializeComponent();
+            ThemeManager.ApplyTheme(this);
+            accountManager = new AccountManager();
+
+            this.Shown -= Accounts_Shown;
+            this.Shown += Accounts_Shown;
+        }
+
+        private async void Accounts_Shown(object sender, EventArgs e)
+        {
+            await RefreshGridAsync();
+        }
+
+        private async Task RefreshGridAsync()
+        {
+            var dt = await accountManager.GetAccountsAsync();
+            if (dt.Columns.Contains("Password"))
+                dt.Columns.Remove("Password");
+            dataGridView1.DataSource = dt;
+        }
+
+        private async void AddBtn_Click(object sender, EventArgs e)
+        {
+            using (var dlg = new UserDialog(accountManager))
+            {
+                if (dlg.ShowDialog() == DialogResult.OK)
+                    await RefreshGridAsync();
+            }
+        }
+
+        private async void EditBtn_Click(object sender, EventArgs e)
+        {
+            if (dataGridView1.SelectedRows.Count == 0)
+            {
+                MessageBox.Show("Seleccione un usuario para editar.", "Usuarios", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            var drv = dataGridView1.SelectedRows[0].DataBoundItem as DataRowView;
+            if (drv == null) return;
+
+            int uid = Convert.ToInt32(drv["Uid"]);
+            string username = drv["Username"]?.ToString() ?? "";
+            Enum.TryParse<UserRole>(drv["Role"]?.ToString(), out var role);
+
+            using (var dlg = new UserDialog(accountManager, uid, username, role))
+            {
+                if (dlg.ShowDialog() == DialogResult.OK)
+                    await RefreshGridAsync();
+            }
+        }
+
+        private async void DeleteBtn_Click(object sender, EventArgs e)
+        {
+            if (dataGridView1.SelectedRows.Count == 0)
+            {
+                MessageBox.Show("Seleccione un usuario para eliminar.", "Usuarios", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            var drv = dataGridView1.SelectedRows[0].DataBoundItem as DataRowView;
+            if (drv == null) return;
+            int uid = Convert.ToInt32(drv["Uid"]);
+
+            if (MessageBox.Show("¿Está seguro de eliminar esta cuenta?", "Advertencia", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+            {
+                await accountManager.DeleteUserAsync(uid);
+                await RefreshGridAsync();
+            }
+        }
+    }
+}

--- a/Views/Account/Accounts.resx
+++ b/Views/Account/Accounts.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Views/Account/UserDialog.Designer.cs
+++ b/Views/Account/UserDialog.Designer.cs
@@ -1,0 +1,141 @@
+namespace RapiMesa
+{
+    partial class UserDialog
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.textBox2 = new System.Windows.Forms.TextBox();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 15);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(77, 19);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Usuario";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 53);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(95, 19);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Contraseña";
+            // 
+            // textBox1
+            // 
+            this.textBox1.Location = new System.Drawing.Point(120, 12);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(214, 27);
+            this.textBox1.TabIndex = 2;
+            // 
+            // textBox2
+            // 
+            this.textBox2.Location = new System.Drawing.Point(120, 50);
+            this.textBox2.Name = "textBox2";
+            this.textBox2.PasswordChar = '*';
+            this.textBox2.Size = new System.Drawing.Size(214, 27);
+            this.textBox2.TabIndex = 3;
+            // 
+            // comboBox1
+            // 
+            this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox1.Location = new System.Drawing.Point(120, 88);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(214, 27);
+            this.comboBox1.TabIndex = 4;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(12, 91);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(49, 19);
+            this.label3.TabIndex = 5;
+            this.label3.Text = "Rol";
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(120, 131);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(98, 37);
+            this.button1.TabIndex = 5;
+            this.button1.Text = "Guardar";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(236, 131);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(98, 37);
+            this.button2.TabIndex = 6;
+            this.button2.Text = "Cancelar";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
+            // 
+            // errorProvider1
+            // 
+            this.errorProvider1.ContainerControl = this;
+            // 
+            // UserDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 19F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(358, 180);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button1);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.comboBox1);
+            this.Controls.Add(this.textBox2);
+            this.Controls.Add(this.textBox1);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Font = new System.Drawing.Font("News706 BT", 12F, System.Drawing.FontStyle.Bold);
+            this.Name = "UserDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Usuario";
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.TextBox textBox2;
+        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.ErrorProvider errorProvider1;
+    }
+}

--- a/Views/Account/UserDialog.cs
+++ b/Views/Account/UserDialog.cs
@@ -1,0 +1,105 @@
+using System;
+using System.ComponentModel;
+using System.Data;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using RapiMesa.Utility;
+using RapiMesa.Data;
+
+namespace RapiMesa
+{
+    public partial class UserDialog : Form
+    {
+        private readonly AccountManager accountManager;
+        private readonly int uid; // 0 = nuevo
+
+        public UserDialog(AccountManager manager)
+        {
+            InitializeComponent();
+            ThemeManager.ApplyTheme(this);
+            accountManager = manager ?? throw new ArgumentNullException(nameof(manager));
+            uid = 0;
+            Text = "Agregar Usuario";
+            comboBox1.DataSource = Enum.GetValues(typeof(UserRole));
+        }
+
+        public UserDialog(AccountManager manager, int uid, string username, UserRole role)
+        {
+            InitializeComponent();
+            ThemeManager.ApplyTheme(this);
+            accountManager = manager ?? throw new ArgumentNullException(nameof(manager));
+            this.uid = uid;
+            Text = "Editar Usuario";
+            textBox1.Text = username;
+            comboBox1.DataSource = Enum.GetValues(typeof(UserRole));
+            comboBox1.SelectedItem = role;
+        }
+
+        private async void button1_Click(object sender, EventArgs e)
+        {
+            await SaveUserAsync();
+        }
+
+        private void button2_Click(object sender, EventArgs e)
+        {
+            errorProvider1.Clear();
+            Close();
+        }
+
+        private async Task<bool> ValidateAllAsync()
+        {
+            errorProvider1.Clear();
+            var name = (textBox1.Text ?? "").Trim();
+            var pass = textBox2.Text ?? "";
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                errorProvider1.SetError(textBox1, "El nombre es obligatorio.");
+                return false;
+            }
+
+            if (uid == 0 && string.IsNullOrWhiteSpace(pass))
+            {
+                errorProvider1.SetError(textBox2, "La contraseña es obligatoria.");
+                return false;
+            }
+
+            var dt = await accountManager.GetAccountsAsync();
+            foreach (DataRow row in dt.Rows)
+            {
+                var existing = row["Username"]?.ToString();
+                int existingUid = Convert.ToInt32(row["Uid"]);
+                if (string.Equals(existing, name, StringComparison.OrdinalIgnoreCase) && existingUid != uid)
+                {
+                    errorProvider1.SetError(textBox1, "El usuario ya existe.");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private async Task SaveUserAsync()
+        {
+            if (!await ValidateAllAsync()) return;
+
+            string username = textBox1.Text.Trim();
+            string password = textBox2.Text;
+            var role = (UserRole)comboBox1.SelectedItem;
+
+            try
+            {
+                if (uid == 0)
+                    await accountManager.RegisterUserAsync(username, password, role);
+                else
+                    await accountManager.UpdateUserAsync(uid, username, password, role);
+
+                DialogResult = DialogResult.OK;
+                Close();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error al guardar usuario:\r\n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+    }
+}

--- a/Views/Account/UserDialog.resx
+++ b/Views/Account/UserDialog.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Views/Category/Category.cs
+++ b/Views/Category/Category.cs
@@ -21,6 +21,13 @@ namespace RapiMesa.InventoryApp.Views
             // Cargar asíncrono cuando el form se muestra
             this.Shown -= Category_Shown;
             this.Shown += Category_Shown;
+
+            if (UserSession.Role == UserRole.Cashier)
+            {
+                button1.Enabled = false;
+                button2.Enabled = false;
+                DeleteBtn.Enabled = false;
+            }
         }
 
         private async void Category_Shown(object sender, EventArgs e)

--- a/Views/MainView.Designer.cs
+++ b/Views/MainView.Designer.cs
@@ -33,6 +33,7 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainView));
             this.panel1 = new System.Windows.Forms.Panel();
             this.darkModeChk = new System.Windows.Forms.CheckBox();
+            this.radioButton6 = new System.Windows.Forms.RadioButton();
             this.radioButton5 = new System.Windows.Forms.RadioButton();
             this.button1 = new System.Windows.Forms.Button();
             this.radioButton4 = new System.Windows.Forms.RadioButton();
@@ -49,6 +50,7 @@
             // 
             this.panel1.BackColor = System.Drawing.Color.Gainsboro;
             this.panel1.Controls.Add(panel3);
+            this.panel1.Controls.Add(this.radioButton6);
             this.panel1.Controls.Add(this.darkModeChk);
             this.panel1.Controls.Add(this.radioButton5);
             this.panel1.Controls.Add(this.button1);
@@ -68,15 +70,29 @@
             this.darkModeChk.Appearance = System.Windows.Forms.Appearance.Button;
             this.darkModeChk.BackColor = System.Drawing.Color.DimGray;
             this.darkModeChk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.darkModeChk.Location = new System.Drawing.Point(2, 290);
+            this.darkModeChk.Location = new System.Drawing.Point(2, 347);
             this.darkModeChk.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.darkModeChk.Name = "darkModeChk";
             this.darkModeChk.Size = new System.Drawing.Size(275, 56);
-            this.darkModeChk.TabIndex = 6;
+            this.darkModeChk.TabIndex = 7;
             this.darkModeChk.Text = "Dark Mode";
             this.darkModeChk.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.darkModeChk.UseVisualStyleBackColor = false;
             this.darkModeChk.CheckedChanged += new System.EventHandler(this.darkModeChk_CheckedChanged);
+
+            // radioButton6
+            this.radioButton6.Appearance = System.Windows.Forms.Appearance.Button;
+            this.radioButton6.BackColor = System.Drawing.Color.RosyBrown;
+            this.radioButton6.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.radioButton6.Location = new System.Drawing.Point(2, 290);
+            this.radioButton6.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            this.radioButton6.Name = "radioButton6";
+            this.radioButton6.Size = new System.Drawing.Size(275, 56);
+            this.radioButton6.TabIndex = 6;
+            this.radioButton6.Text = "Usuarios";
+            this.radioButton6.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.radioButton6.UseVisualStyleBackColor = false;
+            this.radioButton6.CheckedChanged += new System.EventHandler(this.radioButton6_CheckedChanged);
             // 
             // radioButton5
             // 
@@ -227,5 +243,6 @@
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.CheckBox darkModeChk;
         private System.Windows.Forms.RadioButton radioButton5;
+        private System.Windows.Forms.RadioButton radioButton6;
     }
 }

--- a/Views/MainView.cs
+++ b/Views/MainView.cs
@@ -41,7 +41,10 @@ namespace RapiMesa
             itemCountTimer = new Timer { Interval = 1500 }; // 15s mejor que 1s
             itemCountTimer.Tick += itemCountTimer_Tick;
             itemCountTimer.Start();
-        
+
+            SetupPermissions();
+            StartInactivityMonitor();
+
         }
 
         private async void MainView_Shown(object sender, EventArgs e)
@@ -119,6 +122,13 @@ namespace RapiMesa
                 SwitchForm(new Transaction());
         }
 
+        // ACCOUNTS TAB
+        private void radioButton6_CheckedChanged(object sender, EventArgs e)
+        {
+            if (radioButton6.Checked)
+                SwitchForm(new Accounts());
+        }
+
         // LOGOUT BUTTON
         private void button1_Click(object sender, EventArgs e)
         {
@@ -128,11 +138,50 @@ namespace RapiMesa
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning) == DialogResult.Yes)
             {
-                var userauth = new UserAuth();
-                userauth.FormClosed += (s, args) => this.Close();
-                userauth.Show();
-                Hide();
+                Logout();
             }
+        }
+
+        private void Logout()
+        {
+            InactivityMonitor.Stop();
+            var userauth = new UserAuth();
+            userauth.FormClosed += (s, args) => this.Close();
+            userauth.Show();
+            Hide();
+        }
+
+        private void SetupPermissions()
+        {
+            if (UserSession.Role == UserRole.Cashier)
+            {
+                radioButton2.Enabled = false;
+            }
+
+            if (UserSession.Role != UserRole.Administrator)
+            {
+                radioButton6.Enabled = false;
+            }
+        }
+
+        private void StartInactivityMonitor()
+        {
+            InactivityMonitor.Start(300, () =>
+            {
+                if (InvokeRequired)
+                {
+                    BeginInvoke(new Action(() =>
+                    {
+                        MessageBox.Show("Sesión bloqueada por inactividad.", "Inactividad", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        Logout();
+                    }));
+                }
+                else
+                {
+                    MessageBox.Show("Sesión bloqueada por inactividad.", "Inactividad", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    Logout();
+                }
+            });
         }
 
         // CART COUNTER (async)

--- a/Views/Product/Product.cs
+++ b/Views/Product/Product.cs
@@ -24,6 +24,14 @@ namespace RapiMesa
             this.Shown -= Product_Shown;
             this.Shown += Product_Shown;
 
+            if (UserSession.Role == UserRole.Cashier)
+            {
+                AddBtn.Enabled = false;
+                EditBtn.Enabled = false;
+                DeleteBtn.Enabled = false;
+                AddStockBtn.Enabled = false;
+            }
+
             SetupAddToCartButton();
         }
 

--- a/db/Database.sql
+++ b/db/Database.sql
@@ -64,9 +64,10 @@ CREATE TABLE [dbo].[Orders]
 -- Creates a table to store user information
 CREATE TABLE [dbo].[Account]
 (
-	[Uid] INT NOT NULL PRIMARY KEY IDENTITY (1000, 1), 
-    [Username] VARCHAR(50) NULL, 
-    [Password] VARCHAR(50) NULL, 
+        [Uid] INT NOT NULL PRIMARY KEY IDENTITY (1000, 1),
+    [Username] VARCHAR(50) NULL,
+    [Password] VARCHAR(50) NULL,
+    [Role] VARCHAR(20) NULL,
     [Email] VARCHAR(50) NULL,
 );
 


### PR DESCRIPTION
## Summary
- allow listing and management of user accounts with add, edit, delete, and role assignment
- extend account manager with CRUD operations and role persistence
- add role column to Account table and restrict account screen to administrators

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689972f5bfa883248108b782b9f4acd8